### PR TITLE
FIX: Timer is alive if user not resumed and instead closed transcriber

### DIFF
--- a/lib/src/deepgram.dart
+++ b/lib/src/deepgram.dart
@@ -15,7 +15,7 @@ class DeepgramLiveTranscriber {
       {required this.inputAudioStream, this.queryParams});
 
   /// Flag which determines if transcriber was closed
-  bool _isClosed = true;
+  bool _isClosed = false;
 
   /// Flag which determines if web socket throwed error during initialization
   bool _hasInitializationException = false;

--- a/lib/src/deepgram.dart
+++ b/lib/src/deepgram.dart
@@ -90,6 +90,8 @@ class DeepgramLiveTranscriber {
     if (_isClosed) return;
     _isClosed = true;
 
+    _keepAliveTimer?.cancel();
+
     // Close ws sink only when ws has been connected, otherwise future will never complete
     if (!_hasInitializationException) {
       await _wsChannel.sink.close();

--- a/lib/src/deepgram.dart
+++ b/lib/src/deepgram.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
-import 'package:deepgram_speech_to_text/src/utils.dart';
 
+import 'package:deepgram_speech_to_text/src/utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:universal_file/universal_file.dart';
 import 'package:web_socket_channel/status.dart' as status;
@@ -14,7 +14,13 @@ class DeepgramLiveTranscriber {
   DeepgramLiveTranscriber(this.apiKey,
       {required this.inputAudioStream, this.queryParams});
 
-  /// your Deepgram API key
+  /// Flag which determines if transcriber was closed
+  bool _isClosed = true;
+
+  /// Flag which determines if web socket throwed error during initialization
+  bool _hasInitializationException = false;
+
+  /// Your Deepgram API key
   final String apiKey;
 
   /// The audio stream to transcribe.
@@ -27,7 +33,6 @@ class DeepgramLiveTranscriber {
   final StreamController<DeepgramSttResult> _outputTranscriptStream =
       StreamController<DeepgramSttResult>();
   late WebSocketChannel _wsChannel;
-  bool _isClosed = false;
 
   /// Start the transcription process.
   Future<void> start() async {
@@ -39,7 +44,15 @@ class DeepgramLiveTranscriber {
       //   Headers.authorizationHeader: 'Token $apiKey',
       // },
     );
-    await _wsChannel.ready;
+
+    try {
+      await _wsChannel.ready;
+    } catch (_) {
+      // Throw during initialization ws, assign exception to true
+      _hasInitializationException = true;
+      rethrow;
+    }
+
     _isClosed = false;
 
     // can listen only once to the channel
@@ -74,12 +87,28 @@ class DeepgramLiveTranscriber {
   Future<void> close() async {
     if (_isClosed) return;
     _isClosed = true;
-    await _wsChannel.sink.close(status.normalClosure);
-    await _outputTranscriptStream.close();
+
+    // Close ws sink only when ws has been connected, otherwise future will never complete
+    if (!_hasInitializationException) {
+      await _wsChannel.sink.close(status.normalClosure);
+    } else {
+      unawaited(_wsChannel.sink.close(status.normalClosure));
+    }
+
+    // If stream has listener then we can await for close result
+    if (_outputTranscriptStream.hasListener) {
+      await _outputTranscriptStream.close();
+    } else {
+      // Otherwise when stream does not have listener, close will never return future
+      unawaited(_outputTranscriptStream.close());
+    }
   }
 
   /// The result stream of the transcription process.
   Stream<DeepgramSttResult> get stream => _outputTranscriptStream.stream;
+
+  /// Getter for isClosed stream variable
+  bool get isClosed => _isClosed;
 }
 
 /// The Deepgram API client.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   http: ^1.2.1
   universal_file: ^1.0.0
-  web_socket_channel: ^3.0.0
+  web_socket_channel: '>=2.4.0 <4.0.0'
 
 dev_dependencies:
   lints: ^4.0.0


### PR DESCRIPTION
Fixed case when user will close transcriber with timer being alive, being so, timer will live and try to send keep alive even after connection was closed. 

We would have to call resume and then close since timer is being closed in resume only.

As a fix I've added timer.close to close method to ensure that we have closed eveything related with transcriber.