### PR TITLE
Support using short-lived JWT tokens instead of API KEY

### DIFF
--- a/lib/src/deepgram.dart
+++ b/lib/src/deepgram.dart
@@ -19,6 +19,7 @@ class Deepgram {
     this.apiKey, {
     this.baseQueryParams,
     this.baseUrl = 'https://api.deepgram.com/v1',
+    this.isJwt = false,
   }) {
     _listen = DeepgramListen(this);
     _speak = DeepgramSpeak(this);
@@ -42,6 +43,9 @@ class Deepgram {
   /// You can change it to use a proxy or self-hosted instance for example.
   final String baseUrl;
 
+  /// Whether or not the apiKey is a short-lived JWT
+  final bool isJwt;
+
   /// Get the Text to Speech API
   DeepgramSpeak get speak => _speak;
 
@@ -60,7 +64,7 @@ class Deepgram {
           },
           null),
       headers: {
-        Headers.authorization: 'Token $apiKey',
+        Headers.authorization: isJwt ? 'Bearer $apiKey' : 'Token $apiKey',
         Headers.contentType: 'audio/*',
       },
       body: getSampleAudioData(),

--- a/lib/src/deepgram_listen.dart
+++ b/lib/src/deepgram_listen.dart
@@ -22,7 +22,7 @@ class DeepgramListen {
     http.Response res = await http.post(
       buildUrl(_baseSttUrl, _client.baseQueryParams, queryParams),
       headers: {
-        Headers.authorization: 'Token ${_client.apiKey}',
+        Headers.authorization: _client.isJwt ? 'Bearer ${_client.apiKey}' : 'Token ${_client.apiKey}',
       },
       body: data,
     );
@@ -58,7 +58,7 @@ class DeepgramListen {
     http.Response res = await http.post(
       buildUrl(_baseSttUrl, _client.baseQueryParams, queryParams),
       headers: {
-        Headers.authorization: 'Token ${_client.apiKey}',
+        Headers.authorization: _client.isJwt ? 'Bearer ${_client.apiKey}' : 'Token ${_client.apiKey}',
         Headers.contentType: 'application/json',
         Headers.accept: 'application/json',
       },

--- a/lib/src/deepgram_listen.dart
+++ b/lib/src/deepgram_listen.dart
@@ -87,6 +87,7 @@ class DeepgramListen {
     final baseParams = mergeMaps(requiredParams, _client.baseQueryParams);
     return DeepgramLiveListener(_client.apiKey,
         inputAudioStream: audioStream,
+        isJwt: _client.isJwt,
         queryParams: mergeMaps(baseParams, queryParams));
   }
 

--- a/lib/src/deepgram_live_listener.dart
+++ b/lib/src/deepgram_live_listener.dart
@@ -41,7 +41,7 @@ class DeepgramLiveListener {
   Future<void> start() async {
     _wsChannel = WebSocketChannel.connect(
       buildUrl(_baseLiveUrl, null, queryParams),
-      protocols: [isJwt ? 'bearer' : 'token', apiKey],
+      protocols: [isJwt ? 'Bearer' : 'token', apiKey],
     );
 
     try {

--- a/lib/src/deepgram_live_listener.dart
+++ b/lib/src/deepgram_live_listener.dart
@@ -9,7 +9,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 class DeepgramLiveListener {
   /// Create a live transcriber with a start and close method
   DeepgramLiveListener(this.apiKey,
-      {required this.inputAudioStream, this.queryParams});
+      {required this.inputAudioStream, this.queryParams, this.isJwt = false});
 
   /// if transcriber was closed
   bool _isClosed = false;
@@ -29,6 +29,8 @@ class DeepgramLiveListener {
   /// The additionals query parameters.
   final Map<String, dynamic>? queryParams;
 
+  final bool isJwt;
+
   final String _baseLiveUrl = 'wss://api.deepgram.com/v1/listen';
   final StreamController<DeepgramListenResult> _outputTranscriptStream =
       StreamController<DeepgramListenResult>();
@@ -39,7 +41,7 @@ class DeepgramLiveListener {
   Future<void> start() async {
     _wsChannel = WebSocketChannel.connect(
       buildUrl(_baseLiveUrl, null, queryParams),
-      protocols: ['token', apiKey],
+      protocols: [isJwt ? 'bearer' : 'token', apiKey],
     );
 
     try {

--- a/lib/src/deepgram_speak.dart
+++ b/lib/src/deepgram_speak.dart
@@ -22,7 +22,7 @@ class DeepgramSpeak {
     http.Response res = await http.post(
       buildUrl(_baseTtsUrl, _client.baseQueryParams, queryParams),
       headers: {
-        Headers.authorization: 'Token ${_client.apiKey}',
+        Headers.authorization: _client.isJwt ? 'Bearer ${_client.apiKey}' : 'Token ${_client.apiKey}',
         Headers.contentType: 'application/json',
       },
       body: jsonEncode({


### PR DESCRIPTION
Using short-lived JWTs client-side is more secure than API keys. Not sure how you want to handle this option but all I think we need to do is set the header scheme to "Bearer" instead of "Token". This change allows us to create the JWT on demand on our secure backend and lets the client use it instead of the unsecured API key. This PR currently handles it in a non-breaking way but I would argue this should be the default. 

https://developers.deepgram.com/reference/token-based-auth-api/grant-token

```dart
// get JWT from your backend
final token = await createDeepgramToken();

// create a deepgram client using the JWT instead of an API KEY
final deepgram = Deepgram(
  token,
  isJwt: true,
  baseQueryParams: {
    'model': 'nova-2-general',
    'detect_language': true,
    'filler_words': false,
    'punctuation': true,
  },
); 
 ```